### PR TITLE
Enhance numerical stability of Savitzky-Golay coefficient computation.

### DIFF
--- a/python/scipy/savgol-precision/savgol_work.py
+++ b/python/scipy/savgol-precision/savgol_work.py
@@ -180,7 +180,10 @@ def super_stabilised_savgol_coeffs(
     #       errors, but via the internal variable ``pos_internal`` which is ensured to
     #       be an integer for the cases where ``x_center == 0`` (so this is a safe
     #       check)
-    if pos_internal != halflen:
+    # NOTE: for even window lengths it is not possible that ``x_center == 0``, so this
+    #       is checked beforehand (the check against ``halflen`` would fail in this
+    #       case)
+    if window_length % 2 == 0 or pos_internal != halflen:
         correction_factors = _savgol_pinv_correction_factors_with_x_center(
             deriv=deriv,
             polyorder=polyorder,
@@ -216,6 +219,7 @@ def stabilised_savgol_coeffs(
     delta=1.0,
     pos=None,
     use="conv",
+
 ):
     # An alternative method for finding the coefficients when deriv=0 is
     #    t = np.arange(window_length)
@@ -369,7 +373,7 @@ if __name__ == "__main__" and True:
 
     for order in [0, 1, 9, 10]:  # odd and even
         for deriv in [0, 1, 2, 3, 4, 5, 6]:
-            for window_len in [11, 31]:  # to keep computation time reasonable
+            for window_len in [11, 12, 31]:  # to keep computation time reasonable
                 for pos in range(0, window_len):  # all possible positions
                     print(f"Checking {window_len=}  {order=}  {deriv=}  {pos=}")
                     coeffs = mpsig.savgol_coeffs(

--- a/python/scipy/savgol-precision/savgol_work.py
+++ b/python/scipy/savgol-precision/savgol_work.py
@@ -170,6 +170,7 @@ def super_stabilised_savgol_coeffs(
     # to stabilize the pseudo-inverse computation, the columns of the polynomial
     # Vandermonde matrix are normalized to have unit Euclidean norm
     j_column_scales = np.linalg.norm(J_normalized_polyvander, axis=0)
+    j_column_scales[j_column_scales == 0.0] = 1.0
     J_normalized_polyvander /= j_column_scales[np.newaxis, ::]
 
     # then, the correction factors for the subsequent least squares problem are computed

--- a/python/scipy/savgol-precision/savgol_work.py
+++ b/python/scipy/savgol-precision/savgol_work.py
@@ -176,7 +176,11 @@ def super_stabilised_savgol_coeffs(
 
     # of ``x_center != 0``, the correction factors for the subsequent least squares
     # problem are a bit more involved to compute
-    if x_center != 0.0:
+    # NOTE: this is not checked via ``x_center`` which can suffer from floating point
+    #       errors, but via the internal variable ``pos_internal`` which is ensured to
+    #       be an integer for the cases where ``x_center == 0`` (so this is a safe
+    #       check)
+    if pos_internal != halflen:
         correction_factors = _savgol_pinv_correction_factors_with_x_center(
             deriv=deriv,
             polyorder=polyorder,

--- a/python/scipy/savgol-precision/savgol_work.py
+++ b/python/scipy/savgol-precision/savgol_work.py
@@ -1,10 +1,9 @@
-from math import comb
+from math import comb, factorial
 from typing import Literal, Optional, Union
 
 import numpy as np
 from matplotlib import pyplot as plt
 from mpmath import mp
-from scipy._lib._util import float_factorial
 
 import mpsig
 
@@ -92,7 +91,7 @@ def _savgol_pinv_correction_factors(
     # are computed by raising -1 to the power of the iterator
     # therefore, the signs are already pre-multiplied with the only constant factor in
     # the formula, namely ``deriv! * ((x_center * delta) ** (-deriv))``
-    x_center_modified_for_deriv = float_factorial(deriv) * ((x_center * delta) ** (-deriv))
+    x_center_modified_for_deriv = factorial(deriv) * ((x_center * delta) ** (-deriv))
     # the following is equivalent to a multiplication of the factor with the signs,
     # however, since the signs are alternating, they are simply repeated as often as
     # necessary

--- a/python/scipy/savgol-precision/savgol_work.py
+++ b/python/scipy/savgol-precision/savgol_work.py
@@ -1,10 +1,216 @@
+from math import comb, fsum
+from typing import Literal, Optional, Union
 
-from mpmath import mp
-import mpsig
 import numpy as np
 from matplotlib import pyplot as plt
+from mpmath import mp
 from scipy._lib._util import float_factorial
-from scipy.linalg import lstsq
+
+import mpsig
+
+
+def _pinv_correction_factors_normalized_polyvander(
+    pinv_row_idx: int,
+    polyorder: int,
+    polyvander_column_scales: np.ndarray,
+    x_center: float,
+    x_scale: float,
+) -> np.ndarray:
+    """
+    Computes the correction factors for the pseudo-inverse of a normalized polynomial
+    Vandermonde matrix where the x-variable was normalized as ``x_scaled = (x - x_center) / x_scale``.
+    After this normalization, the columns of the Vandermonde matrix ``A`` given by
+    ``A = polyvander(x_scaled, polyorder)`` are scaled to have unit Euclidean norm.
+    These steps ensure the numerical stability of the pseudo-inverse computation, but
+    distorts the pseudo-inverse of the polynomial fit. It will then be matched to the
+    scaled columns of ``A`` who were themselves normalized before, rather than the
+    original columns of ``A`` that are based on ``x``.
+
+    This function computes the correction factors to be applied to the rows of the
+    pseudo-inverse of ``A`` to recover the pseudo-inverse of the polynomial fit based
+    on the original columns of ``A``.
+    Multiplying out all scaling and centering factors and rearranging terms gives the
+    following equation for the correction factors:
+
+    ```
+    phi_ik = ((-1)**(i - k)) * comb(i, k) * ((1.0 / x_scale)**i) * 1.0 / col_scale[i] * (x_center ** (i - k))
+    ```
+
+    where
+
+    - ``k`` is the row index of the pseudo-inverse matrix to be corrected (the ``k``-th
+        row corresponds to the ``k``-th coefficient of the polynomial fit, e.g., ``k=0``
+        corresponds to the constant term ``a0``),
+    - ``i`` is the iterator for the polynomial order
+    - ``comb(i, k)`` is the binomial coefficient, and
+    - ``col_scale[i]`` is the Euclidean norm of the ``i``-th column of the normalized
+        polynomial Vandermonde matrix
+
+    These can be applied to correct the element in the ``k``-th row and the ``j``-th
+    column of the distorted pseudo-inverse ``JD+`` as follows:
+
+    ```
+    J+[k, j] = sum(phi_ik * JD+[i, j] for i in range(k, polyorder + 1))
+    ```
+
+    to obtain the corrected pseudo-inverse ``J+``.
+
+    Parameters
+    ----------
+    pinv_row_idx : int
+        The row index of the pseudo-inverse matrix to be corrected. This corresponds to
+        ``k`` in the above equation.
+    polyorder : int
+        The polynomial order of the polynomial fit.
+    polyvander_column_scales : np.ndarray of shape (polyorder + 1,)
+        The Euclidean norms of the columns of the normalized polynomial Vandermonde matrix.
+    x_center, x_scale : float
+        The centering and scaling factors used to normalize the x-variable.
+
+    Returns
+    -------
+    pinv_correction_factors : np.ndarray of shape (polyorder + 1 - pinv_row_idx,)
+        The correction factors for the pseudo-inverse matrix row corresponding to
+        ``pinv_row_idx``.
+
+    """  # noqa: E501
+
+    # first, the signs are determined by the (-1)**(i - k) factor ...
+    i_vect = np.arange(start=pinv_row_idx, stop=polyorder + 1, dtype=np.int64)
+    signs = (-1) ** (i_vect - pinv_row_idx)
+    # ... followed by the binomial coefficients ...
+    binomials = np.array([comb(i, pinv_row_idx) for i in i_vect], dtype=np.int64)
+    # ... then the factors for the x-variable
+    x_factors = (
+        (x_center ** (i_vect - pinv_row_idx))
+        / (x_scale**i_vect)
+        / polyvander_column_scales[pinv_row_idx::]
+    )
+
+    return signs * binomials * x_factors
+
+
+def _correct_pinv_row_normalized_polyvander(
+    pinv_row_idx: int,
+    pinv_scaled_polyvander: np.ndarray,
+    polyorder: int,
+    polyvander_column_scales: np.ndarray,
+    x_center: float,
+    x_scale: float,
+) -> np.ndarray:
+    """
+    Corrects the ``k``-th row of pseudo-inverse of a normalized polynomial Vandermonde
+    matrix to obtain the ``k``-th row of the pseudo-inverse of the polynomial fit based
+    on the original columns of the Vandermonde matrix.
+    For the correction it relies on floating point accurate summation to avoid loss of
+    precision due to cancellation errors with high polynomial orders.
+    Please refer to the documentation of the function :func:`_pinv_correction_factors_normalized_polyvander`
+    for a detailed explanation of the correction factors.
+
+    Parameters
+    ----------
+    pinv_row_idx : int
+        The row index of the pseudo-inverse matrix to be corrected. This corresponds to
+        ``k`` in the above equation.
+    pinv_scaled_polyvander : np.ndarray of shape (polyorder + 1, m)
+        The pseudo-inverse of the normalized polynomial Vandermonde matrix.
+    polyorder : int
+        The polynomial order of the polynomial fit.
+    polyvander_column_scales : np.ndarray of shape (polyorder + 1,)
+        The Euclidean norms of the columns of the normalized polynomial Vandermonde matrix.
+    x_center, x_scale : float
+        The centering and scaling factors used to normalize the x-variable.
+
+    Returns
+    -------
+    pinv_corrected_polyvander : np.ndarray of shape (polyorder + 1, m)
+        The corrected pseudo-inverse of the polynomial fit that corresponds to the
+        original columns of the polynomial Vandermonde matrix.
+
+    """  # noqa: E501
+
+    correction_factors = _pinv_correction_factors_normalized_polyvander(
+        pinv_row_idx=pinv_row_idx,
+        polyorder=polyorder,
+        polyvander_column_scales=polyvander_column_scales,
+        x_center=x_center,
+        x_scale=x_scale,
+    )
+    return np.array(
+        [
+            fsum(pinv_scaled_polyvander[pinv_row_idx::, j] * correction_factors)
+            for j in range(pinv_scaled_polyvander.shape[1])
+        ]
+    )
+
+
+def super_stabilised_savgol_coeffs(
+    window_length: int,
+    polyorder: int,
+    deriv: int = 0,
+    delta: Union[float, int] = 1.0,
+    pos: Optional[int] = None,
+    use: Literal["conv", "dot"] = "conv",
+) -> np.ndarray:
+
+    if polyorder >= window_length:
+        raise ValueError("polyorder must be less than window_length.")
+
+    halflen, rem = divmod(window_length, 2)
+
+    if pos is None:
+        if rem == 0:
+            pos = halflen - 0.5
+        else:
+            pos = halflen
+
+    if not (0 <= pos < window_length):
+        raise ValueError("pos must be nonnegative and less than " "window_length.")
+
+    if use not in ["conv", "dot"]:
+        raise ValueError("`use` must be 'conv' or 'dot'")
+
+    if deriv > polyorder:
+        coeffs = np.zeros(window_length)
+        return coeffs
+
+    # Form the design matrix A. The columns of A are powers of the integers
+    # from -pos to window_length - pos - 1. The powers (i.e., rows) range
+    # from 0 to polyorder. (That is, A is a vandermonde matrix, but not
+    # necessarily square.)
+    x = np.arange(-pos, window_length - pos, dtype=float)
+
+    if use == "conv":
+        # Reverse so that result can be used in a convolution.
+        x = x[::-1]
+
+    # the stable version of the polynomial Vandermonde matrix is computed
+    x_min, x_max = x.min(), x.max()
+    x_center = 0.5 * (x_min + x_max)
+    x_scale = 0.5 * (x_max - x_min)
+    x_normalized = (x - x_center) / x_scale
+    A_scaled_polyvander = np.polynomial.polynomial.polyvander(x_normalized, polyorder)
+
+    # to stabilize the pseudo-inverse computation, the columns of the polynomial
+    # Vandermonde matrix are normalized to have unit Euclidean norm
+    a_column_scales = np.linalg.norm(A_scaled_polyvander, axis=0)
+    A_scaled_polyvander /= a_column_scales[np.newaxis, ::]
+
+    # then, the pseudo-inverse is computed and corrected to obtain the pseudo-inverse
+    # of the polynomial fit based on the columns the original polynomial Vandermonde
+    # matrix based on the original x-values
+    A_pinv_distorted = np.linalg.pinv(A_scaled_polyvander)
+
+    return (
+        float_factorial(deriv) / delta**deriv
+    ) * _correct_pinv_row_normalized_polyvander(
+        pinv_row_idx=deriv,
+        pinv_scaled_polyvander=A_pinv_distorted,
+        polyorder=polyorder,
+        polyvander_column_scales=a_column_scales,
+        x_center=x_center,
+        x_scale=x_scale,
+    )
 
 
 def stabilised_savgol_coeffs(
@@ -33,8 +239,7 @@ def stabilised_savgol_coeffs(
             pos = halflen
 
     if not (0 <= pos < window_length):
-        raise ValueError("pos must be nonnegative and less than "
-                         "window_length.")
+        raise ValueError("pos must be nonnegative and less than " "window_length.")
 
     if use not in ["conv", "dot"]:
         raise ValueError("`use` must be 'conv' or 'dot'")
@@ -76,7 +281,7 @@ def stabilised_savgol_coeffs(
 
 def simple_savgol_coeffs(window_length, polyorder, pos=None):
     if window_length % 2 != 1:
-        raise ValueError('window_length must be odd when pos is None')
+        raise ValueError("window_length must be odd when pos is None")
     if pos is None:
         pos = window_length // 2
     t = np.arange(window_length)
@@ -87,8 +292,12 @@ def simple_savgol_coeffs(window_length, polyorder, pos=None):
 
 
 def check_savgol_coeffs(c, cref):
-    relerr = np.array([float(abs((c0 - cref0)/cref0)) if cref != 0 else np.inf
-                       for c0, cref0 in zip(c, cref)])
+    relerr = np.array(
+        [
+            float(abs((c0 - cref0) / cref0)) if cref != 0 else np.inf
+            for c0, cref0 in zip(c, cref)
+        ]
+    )
     return relerr
 
 
@@ -98,21 +307,60 @@ if __name__ == "__main__":
     window_len = 51
     order = 10
     pos = 35
+    deriv = 5
+    delta = 0.5
 
-    coeffs = mpsig.savgol_coeffs(window_len, order, pos=pos)
-    cnp = simple_savgol_coeffs(window_len, order, pos=pos)
-    cs = stabilised_savgol_coeffs(window_len, order, pos=pos)
+    coeffs = mpsig.savgol_coeffs(window_len, order, pos=pos, deriv=deriv, delta=delta)
+    if deriv == 0:
+        cnp = simple_savgol_coeffs(window_len, order, pos=pos)
 
-    e_cnp = check_savgol_coeffs(cnp, coeffs)
-    e_cs = check_savgol_coeffs(cs, coeffs)
+    c_sup_s = super_stabilised_savgol_coeffs(
+        window_len, order, pos=pos, deriv=deriv, delta=delta
+    )
+    # c_s = stabilised_savgol_coeffs(window_len, order, pos=pos, deriv=deriv, delta=delta)
 
-    plt.plot(e_cnp, 'o', alpha=0.65,
-             label=f'numpy Polynomial.fit\n(rel err: max {e_cnp.max():8.2e}, mean {np.mean(e_cnp):8.2e})')
-    plt.plot(e_cs, 'd', alpha=0.65,
-             label=f'stabilised_savgol_coeffs\n(rel err: max {e_cs.max():8.2e}, mean {np.mean(e_cs):8.2e}')
+    if deriv == 0:
+        e_cnp = check_savgol_coeffs(cnp, coeffs)
+    e_c_sup_s = check_savgol_coeffs(c_sup_s, coeffs)
+    # e_c_s = check_savgol_coeffs(c_s, coeffs)
+
+    if deriv == 0:
+        plt.plot(
+            e_cnp,
+            "8",
+            alpha=0.65,
+            label=f"numpy Polynomial.fit\n(rel err: max {e_cnp.max():8.2e}, median {np.median(e_cnp):8.2e})",
+        )
+
+    plt.plot(
+        e_c_sup_s,
+        "d",
+        alpha=0.65,
+        label=f"super stabilised_savgol_coeffs\n(rel err: max {e_c_sup_s.max():8.2e}, median {np.median(e_c_sup_s):8.2e}",
+    )
+    # plt.plot(e_c_s, 'x', alpha=0.65,
+    #             label=f'stabilised_savgol_coeffs\n(rel err: max {e_c_s.max():8.2e}, median {np.median(e_c_s):8.2e}')
     plt.legend(shadow=True, framealpha=1)
     plt.grid()
-    plt.title(f'Relative Error of Savitzky-Golay Coefficients\n{window_len=}  {order=}  {pos=}')
-    plt.xlabel('Coefficient index')
-    plt.ylabel('Relative error of coefficient')
+    plt.title(
+        f"Relative Error of Savitzky-Golay Coefficients\n{window_len=}  {order=}  {pos=}, {deriv=}"
+    )
+    plt.xlabel("Coefficient index")
+    plt.ylabel("Relative error of coefficient")
+
+    fig, ax = plt.subplots()
+
+    ax.plot(coeffs, "o", alpha=0.65, label="mpsig.savgol_coeffs")
+    if deriv == 0:
+        ax.plot(cnp, "8", alpha=0.65, label="numpy Polynomial.fit")
+
+    ax.plot(c_sup_s, "d", alpha=0.65, label="super stabilised_savgol_coeffs")
+    # ax.plot(c_s, 'x', alpha=0.65, label='stabilised_savgol_coeffs')
+
+    ax.legend(shadow=True, framealpha=1)
+    ax.grid()
+    ax.set_title(f"Savitzky-Golay Coefficients\n{window_len=}  {order=}  {pos=}")
+    ax.set_xlabel("Coefficient index")
+    ax.set_ylabel("Coefficient value")
+
     plt.show()

--- a/python/scipy/savgol-precision/savgol_work.py
+++ b/python/scipy/savgol-precision/savgol_work.py
@@ -126,13 +126,14 @@ def super_stabilised_savgol_coeffs(
 
     halflen, rem = divmod(window_length, 2)
 
-    if pos is None:
+    pos_internal = pos
+    if pos_internal is None:
         if rem == 0:
-            pos = halflen - 0.5
+            pos_internal = halflen - 0.5
         else:
-            pos = halflen
+            pos_internal = halflen
 
-    if not (0 <= pos < window_length):
+    if not (0 <= pos_internal < window_length):
         raise ValueError("pos must be nonnegative and less than " "window_length.")
 
     if use not in ["conv", "dot"]:
@@ -146,7 +147,12 @@ def super_stabilised_savgol_coeffs(
     # from -pos to window_length - pos - 1. The powers (i.e., rows) range
     # from 0 to polyorder. (That is, A is a vandermonde matrix, but not
     # necessarily square.)
-    x = np.arange(-pos, window_length - pos, dtype=float)
+    x = np.arange(
+        start=-pos_internal,
+        stop=window_length - pos_internal,
+        step=1.0,
+        dtype=float,
+    )
 
     if use == "conv":
         # Reverse so that result can be used in a convolution.


### PR DESCRIPTION
This PR adds a numerically stabilised version of the Savitzky Golay filter computation as described for the Scipy Issue [#20825](https://github.com/scipy/scipy/issues/20825) in [this comment](https://github.com/scipy/scipy/issues/20825#issuecomment-2181539118).